### PR TITLE
fix youtube caption track retrieval

### DIFF
--- a/src/main/webapp/js/captions.js
+++ b/src/main/webapp/js/captions.js
@@ -196,12 +196,12 @@ function beginCaptionRequest(videoId, url) {
             
             if (trackId === "") { // no english track found
                 renderError("No English Captions Track for this Video");
-            } else {
-                getCaptions(trackId, url).then(json => {
-                    // send to backend
-                    sendJsonForm(json);
-                });
+                return;
             }
+            getCaptions(trackId, url).then(json => {
+                // send to backend
+                sendJsonForm(json);
+            });
         }
     }, function(err) {
         // top level error handler
@@ -220,7 +220,6 @@ function getCaptions(trackId, url) {
     return new Promise((success, failure) => {
         gapi.client.youtube.captions.download({
             "id": trackId,
-            //"tlang": "en",
             "tfmt": "sbv"
         }).then(function(response){
             parseCaptionsIntoJson(response, url).then(json => {

--- a/src/main/webapp/js/captions.js
+++ b/src/main/webapp/js/captions.js
@@ -191,6 +191,7 @@ function beginCaptionRequest(videoId, url) {
             for (i = 0; i < response.result.items.length; i++) {
                 if (response.result.items[i].snippet.language === "en") {
                     trackId = response.result.items[i].id;
+                    break;
                 }
             }
             


### PR DESCRIPTION
This should fix the problem we faced when retrieving captions from youtube api.
The problem was tracked to a tlang problem.
When we take captions.list, we get a list of caption tracks.
We were just grabbing the first one and then using tlang to translate that track to english if it wasn't already in english.

New method:
iterate through captions.list, find which one is in english, throw error if none are. (eliminating need for tlang)
this is all done in captions,js